### PR TITLE
Daza110 patch 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "This package provides a user friendly way of interacting with Google Contacts via the Google People API.",
     "type": "library",
     "require": {
-        "rapidwebltd/php-google-oauth-2-handler": "^1.2.1"
+        "rapidwebltd/php-google-oauth-2-handler": "dev-patch-1"
     },
     "license": "LGPL-3.0-only",
     "authors": [


### PR DESCRIPTION
Update GooglePeople class for PHP 8.3 compatibility

- Converted dynamic properties in Contact to explicit typed properties to remove deprecation warnings.
- Replaced (string)$response->getBody() with getContents() for proper stream handling.
- Updated null handling and iteration to avoid warnings on missing fields.
- Fixed `me()` method to call the correct `get()` function.
- Replaced stdClass with arrays in save() requests to comply with PHP 8.3 strictness.
- Fully compatible with PHP 8.3 while maintaining existing functionality.